### PR TITLE
spring-boot-prow-9 to 0.0.6

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,4 +9,4 @@ dependencies:
   version: 2.3.58
 - name: spring-boot-prow-9
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.5
+  version: 0.0.6


### PR DESCRIPTION
Promote spring-boot-prow-9 to version 0.0.6