### PR TITLE
spring-boot-prow-9 to 0.0.11

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,4 +9,4 @@ dependencies:
   version: 2.3.58
 - name: spring-boot-prow-9
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.10
+  version: 0.0.11


### PR DESCRIPTION
Promote spring-boot-prow-9 to version 0.0.11